### PR TITLE
Add Docker support and Postgres setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+pytest_cache
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DB_URL=postgresql+asyncpg://postgres:postgres@db:5432/cardvault

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use official Python image
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app app
+COPY version.json version.json
+
+# Expose port
+EXPOSE 8000
+
+# Run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,21 @@
+"""Application configuration using environment variables."""
+
+from functools import lru_cache
+
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Stores configuration values for the application."""
+
+    db_url: str = "postgresql+asyncpg://postgres:postgres@db:5432/cardvault"
+
+    class Config:
+        env_file = ".env"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return a cached Settings instance."""
+
+    return Settings()

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,23 @@
+"""Database session setup using SQLAlchemy with async support."""
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import get_settings
+
+settings = get_settings()
+
+engine = create_async_engine(settings.db_url, echo=False)
+
+async_session_factory = sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Provide a transactional scope around a series of operations."""
+
+    async with async_session_factory() as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,27 @@
+"""FastAPI application for the silph-cardvault service."""
+
+from fastapi import FastAPI
+
+from app.models.base import Base
+from app.db.session import engine
+
+app = FastAPI(title="silph-cardvault")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    """Create database tables on startup."""
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+@app.get("/version")
+async def get_version() -> dict[str, str]:
+    """Return service version metadata."""
+
+    import json
+    from pathlib import Path
+
+    data = json.loads(Path("version.json").read_text())
+    return data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    env_file: .env
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+  db:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: cardvault
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 sqlalchemy>=2.0
 pytest
+fastapi
+uvicorn[standard]
+asyncpg


### PR DESCRIPTION
## Summary
- add FastAPI, uvicorn and asyncpg dependencies
- set up app configuration and DB session manager
- implement minimal FastAPI app with `/version` endpoint
- add Dockerfile and docker-compose with Postgres service
- provide env example and ignore `.env`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685b4f8281c08332ab67ef29bc1a159f