### PR TITLE
Add CollectionEntry ORM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,15 @@ This project uses [Semantic Versioning](https://semver.org/) (MAJOR.MINOR.PATCH)
 
 ---
 
+## [0.1.2] – 2025-06-25
+### Added
+- `CollectionEntry` model for tracking user-owned cards
+
+---
+
 ## [Unreleased]
 ### Planned
 
-- Design and implement the user-owned card model (CollectionEntry) with tracking fields (condition, quantity, price paid, etc.)
 - Build modular, async-compatible SQLAlchemy models with a shared `BaseModel`
 - Normalize and store card data pulled from the PokéTCG.io API
 - Create a sync pipeline that pulls cards from the API in batches and updates/inserts records safely

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,6 @@
+"""ORM models for the cardvault service."""
+
+from .card import Card
+from .collection import CollectionEntry
+
+__all__ = ["Card", "CollectionEntry"]

--- a/app/models/collection.py
+++ b/app/models/collection.py
@@ -1,0 +1,25 @@
+"""SQLAlchemy model for user-owned card entries."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import String, Integer, Numeric, Date, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class CollectionEntry(Base):
+    """Represents a user's owned card with tracking fields."""
+
+    __tablename__ = "collection_entries"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    card_id: Mapped[str] = mapped_column(String(32), ForeignKey("cards.id"), nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    condition: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    price_paid: Mapped[float | None] = mapped_column(Numeric(10, 2), nullable=True)
+    acquired_at: Mapped[date | None] = mapped_column(Date, nullable=True)
+

--- a/app/tests/test_collection_entry_model.py
+++ b/app/tests/test_collection_entry_model.py
@@ -1,0 +1,26 @@
+"""Tests for the CollectionEntry ORM model."""
+
+from sqlalchemy import create_engine, inspect
+
+from app.models.base import Base
+from app.models.collection import CollectionEntry
+
+
+def test_collection_entry_table_created() -> None:
+    """CollectionEntry model should create the collection_entries table."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    inspector = inspect(engine)
+    assert "collection_entries" in inspector.get_table_names()
+
+    columns = {c["name"] for c in inspector.get_columns("collection_entries")}
+    expected = {
+        "id",
+        "user_id",
+        "card_id",
+        "quantity",
+        "condition",
+        "price_paid",
+        "acquired_at",
+    }
+    assert expected.issubset(columns)

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "name": "silph-cardvault",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pokémon card catalogue and user collection service for Project SILPH.",
   "env": "local",
-  "last_updated": "2025-06-24",
+  "last_updated": "2025-06-25",
   "status": "active"
 }


### PR DESCRIPTION
## Summary
- add `CollectionEntry` model for user-owned cards
- expose new model via `models.__init__`
- add test for new table creation
- bump version to 0.1.2 and update changelog

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b525d3d74833294bc45a134b588d8