### PR TITLE
Add async BaseModel and Alembic support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,16 @@ This project uses [Semantic Versioning](https://semver.org/) (MAJOR.MINOR.PATCH)
 
 ---
 
+## [0.1.3] – 2025-06-26
+### Added
+- Async-compatible `BaseModel` shared across models
+- Alembic migration setup
+
+---
+
 ## [Unreleased]
 ### Planned
 
-- Build modular, async-compatible SQLAlchemy models with a shared `BaseModel`
 - Normalize and store card data pulled from the PokéTCG.io API
 - Create a sync pipeline that pulls cards from the API in batches and updates/inserts records safely
 - Add internal logging and basic rate-limit protection to the sync tool

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,29 @@
+[alembic]
+script_location = alembic
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = INFO
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+
+[alembic:ini]
+
+[sqlalchemy]
+url = postgresql+asyncpg://postgres:postgres@db:5432/cardvault

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,58 @@
+"""Alembic environment with async database support."""
+
+from __future__ import annotations
+
+import asyncio
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+from app.core.config import get_settings
+from app.models import BaseModel
+
+# Alembic Config
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = BaseModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = get_settings().db_url
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    """Run migrations in 'online' mode using an async engine."""
+    configuration = config.get_section(config.config_ini_section)
+    configuration["sqlalchemy.url"] = get_settings().db_url
+    connectable = async_engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.begin() as connection:
+        await connection.run_sync(
+            context.configure, connection=connection, target_metadata=target_metadata
+        )
+        await connection.run_sync(context.run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@
 
 from fastapi import FastAPI
 
-from app.models.base import Base
+from app.models.base import BaseModel
 from app.db.session import engine
 
 app = FastAPI(title="silph-cardvault")
@@ -13,7 +13,7 @@ async def on_startup() -> None:
     """Create database tables on startup."""
 
     async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+        await conn.run_sync(BaseModel.metadata.create_all)
 
 
 @app.get("/version")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 """ORM models for the cardvault service."""
 
+from .base import BaseModel
 from .card import Card
 from .collection import CollectionEntry
 
-__all__ = ["Card", "CollectionEntry"]
+__all__ = ["BaseModel", "Card", "CollectionEntry"]

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -3,7 +3,11 @@
 from sqlalchemy.orm import DeclarativeBase
 
 
-class Base(DeclarativeBase):
-    """Base for all database models."""
+class BaseModel(DeclarativeBase):
+    """Base class for all SQLAlchemy models."""
 
     pass
+
+# Backwards compatible alias
+Base = BaseModel
+

--- a/app/models/card.py
+++ b/app/models/card.py
@@ -8,10 +8,10 @@ from typing import Any
 from sqlalchemy import String, Date, Integer, JSON
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from .base import BaseModel
 
 
-class Card(Base):
+class Card(BaseModel):
     """Represents a reference Pokémon card aligned to the PokéTCG schema."""
 
     __tablename__ = "cards"

--- a/app/models/collection.py
+++ b/app/models/collection.py
@@ -7,10 +7,10 @@ from datetime import date
 from sqlalchemy import String, Integer, Numeric, Date, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from .base import BaseModel
 
 
-class CollectionEntry(Base):
+class CollectionEntry(BaseModel):
     """Represents a user's owned card with tracking fields."""
 
     __tablename__ = "collection_entries"

--- a/app/tests/test_card_model.py
+++ b/app/tests/test_card_model.py
@@ -3,14 +3,14 @@
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
 
-from app.models.base import Base
+from app.models.base import BaseModel
 from app.models.card import Card
 
 
 def test_card_table_created():
     """Card model should create the cards table."""
     engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
+    BaseModel.metadata.create_all(engine)
     inspector = inspect(engine)
     assert "cards" in inspector.get_table_names()
 

--- a/app/tests/test_collection_entry_model.py
+++ b/app/tests/test_collection_entry_model.py
@@ -2,14 +2,14 @@
 
 from sqlalchemy import create_engine, inspect
 
-from app.models.base import Base
+from app.models.base import BaseModel
 from app.models.collection import CollectionEntry
 
 
 def test_collection_entry_table_created() -> None:
     """CollectionEntry model should create the collection_entries table."""
     engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
+    BaseModel.metadata.create_all(engine)
     inspector = inspect(engine)
     assert "collection_entries" in inspector.get_table_names()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 fastapi
 uvicorn[standard]
 asyncpg
+alembic

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "name": "silph-cardvault",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pokémon card catalogue and user collection service for Project SILPH.",
   "env": "local",
-  "last_updated": "2025-06-25",
+  "last_updated": "2025-06-26",
   "status": "active"
 }


### PR DESCRIPTION
## Summary
- rename Base to `BaseModel` and adjust imports
- scaffold Alembic for async migrations
- update requirements
- update version and changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685b5786790c8332bbb16c49cda7101d