### PR TITLE
Add /health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ This project uses [Semantic Versioning](https://semver.org/) (MAJOR.MINOR.PATCH)
 - Async-compatible `BaseModel` shared across models
 - Alembic migration setup
 
+## [0.1.4] – 2025-06-27
+### Added
+- `/health` endpoint for basic service checks with auto-generated OpenAPI docs
+
 ---
 
 ## [Unreleased]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,7 +2,7 @@
 
 from functools import lru_cache
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,8 @@
 
 from fastapi import FastAPI
 
+from app.schemas import HealthResponse
+
 from app.models.base import BaseModel
 from app.db.session import engine
 
@@ -25,3 +27,11 @@ async def get_version() -> dict[str, str]:
 
     data = json.loads(Path("version.json").read_text())
     return data
+
+
+@app.get("/health", response_model=HealthResponse, tags=["Health"])
+async def get_health() -> HealthResponse:
+    """Return basic service health status."""
+
+    return HealthResponse(status="ok")
+

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,6 @@
+"""Aggregated Pydantic schemas for the API."""
+
+from .health import HealthResponse
+
+__all__ = ["HealthResponse"]
+

--- a/app/schemas/health.py
+++ b/app/schemas/health.py
@@ -1,0 +1,10 @@
+"""Pydantic schema for the health check endpoint."""
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    """Represents the service health status."""
+
+    status: str
+

--- a/app/tests/test_health_endpoint.py
+++ b/app/tests/test_health_endpoint.py
@@ -1,0 +1,25 @@
+"""Tests for the /health endpoint."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_health_endpoint() -> None:
+    """/health should return service status."""
+
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_openapi_includes_health() -> None:
+    """/openapi.json should document the /health path."""
+
+    client = TestClient(app)
+    openapi = client.get("/openapi.json")
+    assert openapi.status_code == 200
+    assert "/health" in openapi.json()["paths"]
+
+

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "name": "silph-cardvault",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pokémon card catalogue and user collection service for Project SILPH.",
   "env": "local",
-  "last_updated": "2025-06-26",
+  "last_updated": "2025-06-27",
   "status": "active"
 }


### PR DESCRIPTION
## Summary
- add Pydantic schema for health responses
- expose `/health` endpoint with documentation
- test new endpoint and ensure it appears in OpenAPI schema
- update service version and changelog
- switch config to use `pydantic-settings`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b5d83e2808332adf158a67854a27f