### PR TITLE
Implement PokéTCG card import service

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,7 +2,7 @@
 
 from functools import lru_cache
 
-from pydantic_settings import BaseSettings
+from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,10 @@
+"""Service layer for silph-cardvault."""
+
+from .card_service import fetch_card_data, import_card, normalize_card_data, store_card
+
+__all__ = [
+    "fetch_card_data",
+    "normalize_card_data",
+    "store_card",
+    "import_card",
+]

--- a/app/services/card_service.py
+++ b/app/services/card_service.py
@@ -1,0 +1,88 @@
+"""Service for importing Pokémon cards from the PokéTCG API."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.card import Card
+
+POKETCG_API_URL = "https://api.pokemontcg.io/v2/cards"
+
+
+async def fetch_card_data(card_id: str) -> dict[str, Any]:
+    """Fetch raw card data from the PokéTCG API."""
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{POKETCG_API_URL}/{card_id}")
+        response.raise_for_status()
+        return response.json()["data"]
+
+
+def normalize_card_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Map PokéTCG fields to the Card model schema."""
+
+    release = None
+    if date_str := data.get("set", {}).get("releaseDate"):
+        try:
+            release = dt.date.fromisoformat(date_str)
+        except ValueError:
+            release = dt.datetime.strptime(date_str, "%Y/%m/%d").date()
+
+    return {
+        "id": data.get("id"),
+        "set": data.get("set", {}).get("id"),
+        "series": data.get("set", {}).get("series"),
+        "publisher": None,
+        "generation": None,
+        "release_date": release,
+        "artist": data.get("artist"),
+        "name": data.get("name"),
+        "set_num": data.get("number"),
+        "types": data.get("types"),
+        "supertype": data.get("supertype"),
+        "subtypes": data.get("subtypes"),
+        "level": data.get("level"),
+        "hp": data.get("hp"),
+        "evolvesFrom": data.get("evolvesFrom"),
+        "evolvesTo": data.get("evolvesTo"),
+        "abilities": data.get("abilities"),
+        "attacks": data.get("attacks"),
+        "weaknesses": data.get("weaknesses"),
+        "retreatCost": data.get("retreatCost"),
+        "convertedRetreatCost": data.get("convertedRetreatCost"),
+        "rarity": data.get("rarity"),
+        "flavorText": data.get("flavorText"),
+        "nationalPokedexNumbers": data.get("nationalPokedexNumbers"),
+        "legalities": data.get("legalities"),
+        "resistances": data.get("resistances"),
+        "rules": data.get("rules"),
+        "regulationMark": data.get("regulationMark"),
+        "ancientTrait": data.get("ancientTrait"),
+    }
+
+
+async def store_card(card_data: dict[str, Any], session: AsyncSession) -> Card:
+    """Insert or update a card record in the database."""
+
+    card = await session.get(Card, card_data["id"])
+    if card is None:
+        card = Card(**card_data)
+        session.add(card)
+    else:
+        for key, value in card_data.items():
+            setattr(card, key, value)
+    await session.commit()
+    await session.refresh(card)
+    return card
+
+
+async def import_card(card_id: str, session: AsyncSession) -> Card:
+    """Fetch a card from the PokéTCG API and persist it."""
+
+    raw = await fetch_card_data(card_id)
+    normalized = normalize_card_data(raw)
+    return await store_card(normalized, session)

--- a/app/tests/test_card_service.py
+++ b/app/tests/test_card_service.py
@@ -1,0 +1,89 @@
+"""Tests for the card import service."""
+
+import asyncio
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import BaseModel
+from app.models.card import Card
+from app.services.card_service import import_card, normalize_card_data
+
+SAMPLE_DATA: dict[str, Any] = {
+    "id": "xy1-1",
+    "name": "Venusaur-EX",
+    "supertype": "Pokémon",
+    "subtypes": ["Basic", "EX"],
+    "hp": "180",
+    "types": ["Grass"],
+    "evolvesTo": ["M Venusaur-EX"],
+    "rules": [
+        "Pokémon-EX rule: When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards."
+    ],
+    "attacks": [
+        {
+            "name": "Poison Powder",
+            "cost": ["Grass", "Colorless", "Colorless"],
+            "convertedEnergyCost": 3,
+            "damage": "60",
+            "text": "Your opponent's Active Pokémon is now Poisoned."
+        }
+    ],
+    "weaknesses": [{"type": "Fire", "value": "×2"}],
+    "retreatCost": ["Colorless", "Colorless", "Colorless", "Colorless"],
+    "convertedRetreatCost": 4,
+    "set": {"id": "xy1", "series": "XY", "releaseDate": "2014/02/05"},
+    "number": "1",
+    "artist": "Eske Yoshinob",
+    "rarity": "Rare Holo EX",
+    "nationalPokedexNumbers": [3],
+    "legalities": {"unlimited": "Legal", "expanded": "Legal"},
+}
+
+
+def test_normalize_card_data() -> None:
+    """normalize_card_data should map API fields to model columns."""
+
+    normalized = normalize_card_data(SAMPLE_DATA)
+    assert normalized["id"] == "xy1-1"
+    assert normalized["name"] == "Venusaur-EX"
+    assert normalized["set"] == "xy1"
+    assert normalized["series"] == "XY"
+    assert normalized["release_date"].isoformat() == "2014-02-05"
+
+
+def test_import_card(monkeypatch) -> None:
+    """import_card should fetch, normalize, and store a card."""
+
+    async def mock_get(self, url: str) -> Any:
+        class _Resp:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> Any:
+                return {"data": SAMPLE_DATA}
+
+        return _Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def run() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(BaseModel.metadata.create_all)
+
+        async with async_session() as session:
+            card = await import_card("xy1-1", session)
+            assert card.id == "xy1-1"
+            assert card.name == "Venusaur-EX"
+
+        async with async_session() as session:
+            stored = await session.get(Card, "xy1-1")
+            assert stored is not None
+
+    asyncio.run(run())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ uvicorn[standard]
 asyncpg
 alembic
 pydantic<2.0
+httpx
+aiosqlite


### PR DESCRIPTION
## Summary
- add card import service using httpx
- expose service functions via app.services
- adjust configuration to use pydantic BaseSettings
- include new async sqlite dependency
- test card normalization and storage via mocked HTTP call

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b70bd9330833290527bad16235f8b